### PR TITLE
Fix misspelled icon path

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -27,7 +27,7 @@ theme:
     logo: material/library
     repo: fontawesome/brands/gitlab
     admonition:
-      note: fontawesom/solid/sticky-note
+      note: fontawesome/solid/note-sticky
       abstract: octicons/checklist-16
       info: octicons/info-16
       success: octicons/check-16


### PR DESCRIPTION
The icon read note-sticky and not sticky-note and in addition the word
fontawesome was missing an e.

To check the icons, you can use the icons and emoji browser in the
documentation: https://squidfunk.github.io/mkdocs-material/reference/icons-emojis/

The search bar let's you any icon or emoji and presents you the markdown
tag. To get a filename out of it, just replace the first two dashes with
slashes:

:fontawesome-solid-note-sticky: becomes fontawesome/solid/note-sticky

Fixes #53
